### PR TITLE
remove warnings of File.exists?

### DIFF
--- a/lib/transpec/file_finder.rb
+++ b/lib/transpec/file_finder.rb
@@ -12,7 +12,7 @@ module Transpec
           file_paths.concat(ruby_files_in_directory(path))
         elsif File.file?(path)
           file_paths << path
-        elsif !File.exists?(path)
+        elsif !File.exist?(path)
           fail ArgumentError, "No such file or directory #{path.inspect}"
         end
       end

--- a/lib/transpec/git.rb
+++ b/lib/transpec/git.rb
@@ -10,7 +10,7 @@ module Transpec
     def command_available?
       ENV['PATH'].split(File::PATH_SEPARATOR).any? do |path|
         git_path = File.join(path, GIT)
-        File.exists?(git_path)
+        File.exist?(git_path)
       end
     end
 

--- a/spec/support/file_helper.rb
+++ b/spec/support/file_helper.rb
@@ -9,7 +9,7 @@ module FileHelper
     file_path = File.expand_path(file_path)
 
     dir_path = File.dirname(file_path)
-    FileUtils.makedirs(dir_path) unless File.exists?(dir_path)
+    FileUtils.makedirs(dir_path) unless File.exist?(dir_path)
 
     File.open(file_path, 'w') do |file|
       case content


### PR DESCRIPTION
Ruby warned following message running with -w options.

```
warning: File.exists? is a deprecated name, use File.exist? instead
```
