### PR TITLE
Allow activesupport3 as well as activesupport4.

### DIFF
--- a/transpec.gemspec
+++ b/transpec.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'bundler',       '~> 1.3'
   spec.add_runtime_dependency 'rainbow',       '>= 1.99.1', '< 3.0'
   spec.add_runtime_dependency 'json',          '~> 1.8'
-  spec.add_runtime_dependency 'activesupport', '~> 4.0'
+  spec.add_runtime_dependency 'activesupport', '~> 3'
 
   spec.add_development_dependency 'rake',          '~> 10.1'
   spec.add_development_dependency 'rspec',         '~> 2.14'


### PR DESCRIPTION
Either activesupport has what we need, and it seems unnecessary/bad to make
people upgrade from rails3 to rails4 just so they can run
transpec.

With this change, I was able to run transpec on a large rails 3.0 app and it has been working great.
