### PR TITLE
unstub without parens

### DIFF
--- a/spec/transpec/syntax/method_stub_spec.rb
+++ b/spec/transpec/syntax/method_stub_spec.rb
@@ -677,8 +677,9 @@ module Transpec
             let(:source) do
               <<-END
                 describe 'example' do
-                  it 'does not respond to #foo' do
+                  it 'does not respond to #foo or #bar' do
                     subject.#{method}(:foo)
+                    subject.#{method} :bar
                   end
                 end
               END
@@ -687,8 +688,9 @@ module Transpec
             let(:expected_source) do
               <<-END
                 describe 'example' do
-                  it 'does not respond to #foo' do
+                  it 'does not respond to #foo or #bar' do
                     allow(subject).to receive(:foo).and_call_original
+                    allow(subject).to receive(:bar).and_call_original
                   end
                 end
               END


### PR DESCRIPTION
i ran into a conversion issue with arguments without parens.  the code seems to try to account for this with `range_in_between_selector_and_arg`, but it doesn't seem to be working.

i didnt have to dig into why this spec isnt running correctly, nor into the actual code for a solution, but wanted to document it in the meantime.
