### PR TITLE
fix(directory_cloner): lchmod error not cought

### DIFF
--- a/lib/transpec/directory_cloner.rb
+++ b/lib/transpec/directory_cloner.rb
@@ -46,7 +46,7 @@ module Transpec
       source_mode = File.lstat(source).mode
       begin
         File.lchmod(source_mode, destination)
-      rescue NotImplementedError, Errno::ENOSYS
+      rescue NotImplementedError, Errno::ENOSYS, Errno::EOPNOTSUPP
         # Should not change mode of symlink's destination.
         File.chmod(source_mode, destination) unless File.symlink?(destination)
       end


### PR DESCRIPTION
Just stumbled on an issue regarding lchmod on manjaro linux using ruby 2.5.9:

```
$ transpec spec/models/bonus_payout_bu_margin_spec.rb
Copying the project for dynamic analysis...
Traceback (most recent call last):
	21: from /home/kaspi/.rbenv/versions/2.5.9/bin/transpec:23:in `<main>'
	20: from /home/kaspi/.rbenv/versions/2.5.9/bin/transpec:23:in `load'
	19: from /home/kaspi/.rbenv/versions/2.5.9/lib/ruby/gems/2.5.0/gems/transpec-3.4.0/bin/transpec:7:in `<top (required)>'
	18: from /home/kaspi/.rbenv/versions/2.5.9/lib/ruby/gems/2.5.0/gems/transpec-3.4.0/lib/transpec/cli.rb:19:in `run'
	17: from /home/kaspi/.rbenv/versions/2.5.9/lib/ruby/gems/2.5.0/gems/transpec-3.4.0/lib/transpec/cli.rb:38:in `run'
	16: from /home/kaspi/.rbenv/versions/2.5.9/lib/ruby/gems/2.5.0/gems/transpec-3.4.0/lib/transpec/cli.rb:53:in `process'
	15: from /home/kaspi/.rbenv/versions/2.5.9/lib/ruby/gems/2.5.0/gems/transpec-3.4.0/lib/transpec/cli.rb:73:in `run_dynamic_analysis'
	14: from /home/kaspi/.rbenv/versions/2.5.9/lib/ruby/gems/2.5.0/gems/transpec-3.4.0/lib/transpec/cli.rb:73:in `new'
	13: from /home/kaspi/.rbenv/versions/2.5.9/lib/ruby/gems/2.5.0/gems/transpec-3.4.0/lib/transpec/dynamic_analyzer.rb:25:in `initialize'
	12: from /home/kaspi/.rbenv/versions/2.5.9/lib/ruby/gems/2.5.0/gems/transpec-3.4.0/lib/transpec/dynamic_analyzer.rb:56:in `in_copied_project'
	11: from /home/kaspi/.rbenv/versions/2.5.9/lib/ruby/2.5.0/tmpdir.rb:93:in `mktmpdir'
	10: from /home/kaspi/.rbenv/versions/2.5.9/lib/ruby/gems/2.5.0/gems/transpec-3.4.0/lib/transpec/dynamic_analyzer.rb:57:in `block in in_copied_project'
	 9: from /home/kaspi/.rbenv/versions/2.5.9/lib/ruby/gems/2.5.0/gems/transpec-3.4.0/lib/transpec/directory_cloner.rb:22:in `copy_recursively'
	 8: from /home/kaspi/.rbenv/versions/2.5.9/lib/ruby/2.5.0/find.rb:43:in `find'
	 7: from /home/kaspi/.rbenv/versions/2.5.9/lib/ruby/2.5.0/find.rb:43:in `each'
	 6: from /home/kaspi/.rbenv/versions/2.5.9/lib/ruby/2.5.0/find.rb:48:in `block in find'
	 5: from /home/kaspi/.rbenv/versions/2.5.9/lib/ruby/2.5.0/find.rb:48:in `catch'
	 4: from /home/kaspi/.rbenv/versions/2.5.9/lib/ruby/2.5.0/find.rb:49:in `block (2 levels) in find'
	 3: from /home/kaspi/.rbenv/versions/2.5.9/lib/ruby/gems/2.5.0/gems/transpec-3.4.0/lib/transpec/directory_cloner.rb:25:in `block in copy_recursively'
	 2: from /home/kaspi/.rbenv/versions/2.5.9/lib/ruby/gems/2.5.0/gems/transpec-3.4.0/lib/transpec/directory_cloner.rb:40:in `copy'
	 1: from /home/kaspi/.rbenv/versions/2.5.9/lib/ruby/gems/2.5.0/gems/transpec-3.4.0/lib/transpec/directory_cloner.rb:48:in `copy_permission'
/home/kaspi/.rbenv/versions/2.5.9/lib/ruby/gems/2.5.0/gems/transpec-3.4.0/lib/transpec/directory_cloner.rb:48:in `lchmod': Operation not supported - while copying "/home/kaspi/work/controllr/node_modules/@babel/template/node_modules/.bin/parser". (Errno::EOPNOTSUPP)
````

With this change transpec works for me on that box.